### PR TITLE
(maint) Update channels.list API call to conversations.list

### DIFF
--- a/lib/slack.js
+++ b/lib/slack.js
@@ -18,7 +18,7 @@ export default class SlackData extends EventEmitter {
 
   init (){
     request
-    .get(`https://${this.host}.slack.com/api/channels.list`)
+    .get(`https://${this.host}.slack.com/api/conversations.list`)
     .query({ token: this.token })
     .end((err, res) => {
       if (err) {

--- a/test/index.js
+++ b/test/index.js
@@ -15,7 +15,7 @@ describe('slackin', () => {
         });
 
       nock('https://myorg.slack.com')
-        .get('/api/channels.list?token=mytoken')
+        .get('/api/conversations.list?token=mytoken')
         .reply(200, {
           ok: true,
           channels: [{}]
@@ -89,7 +89,7 @@ describe('slackin', () => {
         });
 
       nock('https://myorg.slack.com')
-        .get('/api/channels.list?token=mytoken')
+        .get('/api/conversations.list?token=mytoken')
         .reply(200, {
           ok: true,
           channels: [{}]


### PR DESCRIPTION
[Slack deprecated](https://api.slack.com/methods/channels.list) the
`channels.list` API in favor of `conversations.list`. This updates to
the newer API, which seems to have the same return structure as
`channels.list`. This should be the only update needed (hopefully).